### PR TITLE
Add option to provide custom date of the egg harvest

### DIFF
--- a/tests/Kernel/QuickEggsTest.php
+++ b/tests/Kernel/QuickEggsTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\farm_eggs\Kernel;
 
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 
 /**
@@ -53,6 +54,9 @@ class QuickEggsTest extends QuickFormTestBase {
    */
   public function testQuickEggsWithLocation() {
 
+    // Get today's date.
+    $today = new DrupalDateTime('midnight');
+
     // Create an egg producer to record harvest for.
     $chickens = $this->assetStorage->create([
       'type' => 'group',
@@ -80,6 +84,10 @@ class QuickEggsTest extends QuickFormTestBase {
 
     // Submit the egg harvest quick form.
     $this->submitQuickForm([
+      'date' => [
+        'date' => $today->format('Y-m-d'),
+        'time' => $today->format('H:i:s'),
+      ],
       'assets' => [$chickens->id() => strval($chickens->id())],
       'quantity' => 12,
     ]);
@@ -93,6 +101,7 @@ class QuickEggsTest extends QuickFormTestBase {
     /** @var \Drupal\log\Entity\LogInterface $harvestLog */
     $harvestLog = reset($harvestLogs);
     $this->assertInstanceOf('Drupal\log\Entity\LogInterface', $harvestLog);
+    $this->assertEquals($today->getTimestamp(), $harvestLog->get('timestamp')->value);
     $this->assertEquals(
       '12',
       $harvestLog->get('quantity')->referencedEntities()[0]->get('value')[0]->get('decimal')->getValue(),


### PR DESCRIPTION
Depends on https://github.com/farmOS/farm_eggs/pull/6 since test class is added there but the main changes this pr introduces are in the https://github.com/farmOS/farm_eggs/commit/5569cd4e2fe3a9c7de43bbe8af616eafeb50f146.

Similar to https://github.com/farmOS/farm_eggs/pull/3 but for v2.

Adds date and time field to the quick form, with default value of the moment of opening the form. By default, you can still just select asset, enter egg quantity and submit. But if needed, you can also customize the date and time of the harvest, to for example record an egg harvest that took place yesterday or record an egg harvest a few hours later with the correct timestamp.