### PR TITLE
Add option to provide notes about the egg harvest

### DIFF
--- a/src/Plugin/QuickForm/Eggs.php
+++ b/src/Plugin/QuickForm/Eggs.php
@@ -162,6 +162,18 @@ class Eggs extends QuickFormBase {
       );
     }
 
+    // Notes.
+    $form['notes'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Notes'),
+    ];
+    $form['notes']['notes'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Notes'),
+      '#title_display' => 'invisible',
+      '#format' => 'default',
+    ];
+
     return $form;
   }
 
@@ -203,6 +215,7 @@ class Eggs extends QuickFormBase {
         ],
       ],
       'location' => $locations,
+      'notes' => $form_state->getValue('notes'),
     ]);
 
   }

--- a/tests/Kernel/QuickEggsTest.php
+++ b/tests/Kernel/QuickEggsTest.php
@@ -82,6 +82,9 @@ class QuickEggsTest extends QuickFormTestBase {
       'status' => 'done',
     ])->save();
 
+    // Prepare harvest notes content.
+    $notes = 'Lorem ipsum';
+
     // Submit the egg harvest quick form.
     $this->submitQuickForm([
       'date' => [
@@ -90,6 +93,10 @@ class QuickEggsTest extends QuickFormTestBase {
       ],
       'assets' => [$chickens->id() => strval($chickens->id())],
       'quantity' => 12,
+      'notes' => [
+        'value' => $notes,
+        'format' => 'default',
+      ],
     ]);
 
     // Confirm egg harvest log was created.
@@ -108,6 +115,7 @@ class QuickEggsTest extends QuickFormTestBase {
     );
     $this->assertEquals($chickens->id(), $harvestLog->get('asset')->target_id);
     $this->assertEquals($location->id(), $harvestLog->get('location')->target_id);
+    $this->assertEquals($notes, $harvestLog->get('notes')->getValue()[0]['value']);
   }
 
   /**


### PR DESCRIPTION
Depends on https://github.com/farmOS/farm_eggs/pull/6 since the test class is added there but the main changes this pr introduces are in https://github.com/farmOS/farm_eggs/commit/fbad9f696b0f5b0e30e82bb67bcf37416721f4a9.

Adds `Notes` field to the quick form to allow recording additional notes about an egg harvest.